### PR TITLE
Fixed the Paper Server download URL.

### DIFF
--- a/src/main/java/de/gnmyt/mcdash/api/installer/PaperInstaller.java
+++ b/src/main/java/de/gnmyt/mcdash/api/installer/PaperInstaller.java
@@ -11,8 +11,8 @@ import java.util.HashMap;
 
 public class PaperInstaller implements VersionInstaller {
 
-    private static final String PAPER_URL = "https://papermc.io/api/v2/projects/paper/versions/%s/builds/%s/downloads/paper-%s-%s.jar";
-    private static final String PAPER_API = "https://papermc.io/api/v2/projects/paper/versions/%s";
+    private static final String PAPER_URL = "https://api.papermc.io/v2/projects/paper/versions/%s/builds/%s/downloads/paper-%s-%s.jar";
+    private static final String PAPER_API = "https://api.papermc.io/v2/projects/paper/versions/%s";
 
     private final OkHttpClient client = new OkHttpClient();
     private final Logger LOG = new Logger(PaperInstaller.class);


### PR DESCRIPTION
Fixed the Paper Server download URL. Spigot does not work anymore because getbukkit now only has a paid API subscription, thus more effort would have to be put into compiling the jar on the system the server is to be installed on. Purpur still seems to work. Fabric will have to be added in the future.